### PR TITLE
Update config to use environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Dieses Projekt bietet ein Python-Skript, das Dokumente in einer [Paperless-ngx](
    Folge den [Installationsanweisungen von OLLama](https://ollama.ai/download).
 
 ## Konfiguration
-1. **API-Details anpassen:** Bearbeite die Variablen `PAPERLESS_URL` und `API_KEY` im Skript, um die URL und den API-Key deiner Paperless-ngx-Instanz anzugeben.
+1. **API-Details setzen:** Lege die Umgebungsvariablen `PAPERLESS_URL` und `API_KEY` fest, um die URL und den API-Key deiner Paperless-ngx-Instanz anzugeben, bevor du das Skript startest.
 2. **OLLama-Modell:** Stelle sicher, dass das Modell `llama3.2:3b` in deiner OLLama-Instanz verfügbar ist.
 3. **Optionen konfigurieren:**
    - `SAVE_CHANGES`: Ändere auf `False`, um Änderungen in Paperless-ngx zu deaktivieren.
@@ -118,7 +118,7 @@ This project provides a Python script for automating document analysis and categ
    Follow the [OLLama installation guide](https://ollama.ai/download).
 
 ## Configuration
-1. **Adjust API details:** Edit the variables `PAPERLESS_URL` and `API_KEY` in the script to set your Paperless-ngx instance's URL and API key.
+1. **Set API details:** Define the environment variables `PAPERLESS_URL` and `API_KEY` with your Paperless-ngx instance's URL and API key before starting the script.
 2. **OLLama model:** Ensure the `llama3.2:3b` model is available in your OLLama instance.
 3. **Configure options:**
    - `SAVE_CHANGES`: Set to `False` to disable changes in Paperless-ngx.

--- a/paperless-localollama.py
+++ b/paperless-localollama.py
@@ -1,12 +1,18 @@
+import os
 import requests
 import subprocess
 import json
 import re
 import random
 
-# Paperless-ngx API-Details
-PAPERLESS_URL = "http://IP:9466"
-API_KEY = "API_KEY"
+# Paperless-ngx API-Details aus Umgebungsvariablen beziehen
+PAPERLESS_URL = os.getenv("PAPERLESS_URL")
+API_KEY = os.getenv("API_KEY")
+
+if not PAPERLESS_URL or not API_KEY:
+    raise EnvironmentError(
+        "PAPERLESS_URL and API_KEY environment variables must be set"
+    )
 HEADERS = {
     "Authorization": f"Token {API_KEY}",
     "Accept": "application/json; version=6"


### PR DESCRIPTION
## Summary
- read Paperless config from `PAPERLESS_URL` and `API_KEY` env vars
- document new env vars in both German and English sections of the README

## Testing
- `python3 -m py_compile paperless-localollama.py`

------
https://chatgpt.com/codex/tasks/task_e_6842805ee10083299ad816cba95729b4