### PR TITLE
Make OLLama command configurable

### DIFF
--- a/paperless-localollama.py
+++ b/paperless-localollama.py
@@ -3,6 +3,7 @@ import subprocess
 import json
 import re
 import random
+import shlex
 
 # Paperless-ngx API-Details
 PAPERLESS_URL = "http://IP:9466"
@@ -206,7 +207,7 @@ def analyze_with_ollama(content, existing_tags, timeout=60):
     )
 
     print("Starte Analyse mit OLLama ...")
-    command = ["ollama", "run", "llama3.2:3b"]
+    command = shlex.split(OLLAMA_COMMAND)
     process = subprocess.Popen(
         command,
         stdin=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- add `shlex` import
- allow customizing OLLama command with `OLLAMA_COMMAND`

## Testing
- `python3 -m py_compile paperless-localollama.py`


------
https://chatgpt.com/codex/tasks/task_e_68428063c9e88329b35fad7da534e0a9